### PR TITLE
Improve note detection calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Pre-built releases for Linux and Windows are available on the [GitHub Releases](
 4. **Audio Device:** Select the specific audio device from the dropdown.
 5. Click **Start Listening** to begin detecting notes. Detected notes will send keystrokes and appear in the log.
 6. Click **Stop Listening** to end.
+7. Use **Calibrate Selected Device** in Settings to measure background noise and
+   optionally run pitch calibration for more reliable note detection.
 
 ## Configuration Persistence
 

--- a/audiokeys/gui.py
+++ b/audiokeys/gui.py
@@ -6,9 +6,8 @@ audiokeys — PySide 6
 
 from __future__ import annotations
 
-import os
 import sys
-from typing import MutableMapping, Optional
+from typing import Optional
 
 from q_materialise import inject_style
 

--- a/audiokeys/key_sender.py
+++ b/audiokeys/key_sender.py
@@ -35,9 +35,9 @@ source.
 # AudioKeys is not installed (e.g. during development), fall back to
 # sibling modules in the same directory.
 try:
-    from audiokeys.utils import elevate_and_setup_uinput, resource_path  # type: ignore
+    from audiokeys.utils import elevate_and_setup_uinput  # type: ignore
 except Exception:
-    from utils import elevate_and_setup_uinput, resource_path  # type: ignore
+    from utils import elevate_and_setup_uinput  # type: ignore
 
 
 class KeySender:
@@ -133,7 +133,9 @@ class KeySender:
 
         # If we still have no codes (unlikely), fall back to default letter set
         if not requested_codes:
-            requested_codes = {getattr(uinput, f"KEY_{c}") for c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ"}
+            requested_codes = {
+                getattr(uinput, f"KEY_{c}") for c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            }
 
         # Attempt to open the uinput device
         try:
@@ -146,7 +148,7 @@ class KeySender:
                 "Elevated Privileges Required",
                 "Cannot open /dev/uinput—\n"
                 "you need permission to access the uinput device.\n\n"
-                "Audiokeys will attempt to configure your system now."
+                "Audiokeys will attempt to configure your system now.",
             )
             # Our helper to write the udev rule, reload rules, add group, etc.
             elevate_and_setup_uinput()
@@ -163,6 +165,7 @@ class KeySender:
         print(f"⚠️  {reason}")
         try:
             from pynput.keyboard import Controller  # type: ignore
+
             self.ctrl = Controller()
             self.backend = "pynput"
         except ImportError:

--- a/audiokeys/note_calibration.py
+++ b/audiokeys/note_calibration.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Mapping
+from typing import Callable, Iterable, Mapping, Optional
 
 import numpy as np
 
-from .constants import A4_FREQ, A4_MIDI
+from .constants import A4_FREQ, A4_MIDI, NOTE_NAMES
 
 
 def _freq_to_midi(freq: float) -> float:
@@ -40,7 +40,119 @@ def detect_pitch_fft(samples: np.ndarray, sample_rate: int) -> float:
     return float(freqs[mask][idx])
 
 
+def midi_to_freq(midi: float) -> float:
+    """Convert MIDI number to frequency using A4 reference."""
+    return A4_FREQ * 2 ** ((midi - A4_MIDI) / 12.0)
+
+
+def note_to_midi(note: str, octave: int = 4) -> int:
+    """Return MIDI number for ``note`` in the given octave."""
+    idx = NOTE_NAMES.index(note)
+    return idx + (octave + 1) * 12
+
+
+def calibrate_pitches(
+    notes: Iterable[str] = NOTE_NAMES,
+    *,
+    duration: float = 2.0,
+    sample_rate: int = 44_100,
+    hop_size: int = 512,
+    channels: int = 1,
+    octave: int = 4,
+    device: Optional[int] = None,
+    record_func: Optional[
+        Callable[[str, float, int, int, Optional[int]], np.ndarray]
+    ] = None,
+    interactive: bool = True,
+) -> Mapping[str, list[float]]:
+    """Interactively measure pitches for a sequence of notes.
+
+    Parameters
+    ----------
+    notes:
+        Iterable of note names (e.g. ``"C#"``) to record.
+    duration:
+        Recording time in seconds for each note.
+    sample_rate:
+        Sampling rate used when recording.
+    hop_size:
+        Frame size for pitch extraction.
+    channels:
+        Number of input channels to record.
+    octave:
+        Octave of notes being played. ``4`` corresponds to middle C.
+    device:
+        Optional sounddevice input device index.
+    record_func:
+        Custom audio capture callable used instead of ``sounddevice``.
+        The callable is invoked as ``record_func(note, duration, sample_rate, channels, device)``
+        and must return a ``numpy.ndarray`` of samples.
+    interactive:
+        When ``True`` the user is prompted before each recording.
+
+    Returns
+    -------
+    Mapping[str, list[float]]
+        Recorded pitch frequencies for each note.
+    """
+    if record_func is None:
+        from sounddevice import rec, wait  # type: ignore
+
+        def record_func(
+            note: str,
+            dur: float,
+            rate: int,
+            ch: int,
+            dev: Optional[int],
+        ) -> np.ndarray:
+            data = rec(
+                int(dur * rate),
+                samplerate=rate,
+                channels=ch,
+                device=dev,
+                dtype="float32",
+            )
+            wait()
+            if data.ndim > 1:
+                data = data.mean(axis=1)
+            return data.reshape(-1)
+
+    results: dict[str, list[float]] = {}
+    for note in notes:
+        attempts = 0
+        while attempts < 3:
+            attempts += 1
+            if interactive:
+                input(f"Play note {note} and press Enter to start recording…")
+            samples = record_func(note, duration, sample_rate, channels, device)
+            freqs: list[float] = []
+            for start in range(0, len(samples), hop_size):
+                block = samples[start : start + hop_size]
+                freq = detect_pitch_fft(block, sample_rate)
+                if freq > 0:
+                    freqs.append(freq)
+            if not freqs:
+                if interactive:
+                    print("No pitch detected, retrying…")
+                continue
+            median = float(np.median(freqs))
+            expected = midi_to_freq(note_to_midi(note, octave))
+            spread = np.percentile(freqs, 75) - np.percentile(freqs, 25)
+            if spread / median < 0.05 and abs(median - expected) / expected < 0.03:
+                results[note] = freqs
+                break
+            if interactive:
+                print("Pitch unstable, try again…")
+        else:
+            results[note] = freqs
+
+    return results
+
+
 __all__ = [
     "calculate_midi_tolerance",
     "detect_pitch_fft",
+    "midi_to_freq",
+    "note_to_midi",
+    "calibrate_pitches",
 ]

--- a/audiokeys/streams.py
+++ b/audiokeys/streams.py
@@ -26,7 +26,7 @@ def route_stream_to_null_sink(sink_input_idx: int, sink_name="audiokeys_null"):
     # create the sink once
     sinks = [s for s in pc.sink_list() if s.name == sink_name]
     if not sinks:
-        mod_idx = pc.module_load("module-null-sink", f"sink_name={sink_name}")
+        pc.module_load("module-null-sink", f"sink_name={sink_name}")
         sinks = [s for s in pc.sink_list() if s.name == sink_name]
 
     null_sink = sinks[0]

--- a/tests/test_note_calibration.py
+++ b/tests/test_note_calibration.py
@@ -1,6 +1,10 @@
 import numpy as np
 
-from audiokeys.note_calibration import calculate_midi_tolerance, detect_pitch_fft
+from audiokeys.note_calibration import (
+    calculate_midi_tolerance,
+    detect_pitch_fft,
+    calibrate_pitches,
+)
 
 
 def test_detect_pitch_fft_sine():
@@ -19,3 +23,25 @@ def test_calculate_midi_tolerance():
     }
     tol = calculate_midi_tolerance(data)
     assert 0.1 <= tol <= 1.0
+
+
+def test_calibrate_pitches_stub():
+    sr = 44100
+    freq_map = {"C": 261.63, "C#": 277.18}
+
+    def fake_rec(note: str, duration: float, rate: int, ch: int, dev):
+        t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+        f = freq_map[note]
+        return np.sin(2 * np.pi * f * t).astype(np.float32)
+
+    data = calibrate_pitches(
+        ["C", "C#"],
+        duration=0.2,
+        sample_rate=sr,
+        hop_size=2048,
+        record_func=fake_rec,
+        interactive=False,
+    )
+    assert set(data.keys()) == {"C", "C#"}
+    assert len(data["C"]) > 0
+    assert abs(np.median(data["C"]) - freq_map["C"]) < 5.0


### PR DESCRIPTION
## Summary
- add new `calibrate_pitches` routine for guided pitch calibration
- expose helper functions for midi/frequency conversion
- update GUI imports and cleanup unused code
- fix minor style issues flagged by lint
- document calibration in README
- test pitch calibration stub

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68890cc2c69c8322bf9ae7e10ff45979