### PR TITLE
Enable sample-based key mapping

### DIFF
--- a/audiokeys/__init__.py
+++ b/audiokeys/__init__.py
@@ -1,0 +1,15 @@
+"""Audiokeys package."""
+
+from .sample_matcher import cosine_similarity, match_sample, record_until_silence
+
+try:  # sounddevice may be missing in test environments
+    from .sound_worker import SoundWorker
+except Exception:  # pragma: no cover - optional dependency
+    SoundWorker = None  # type: ignore
+
+__all__ = [
+    "cosine_similarity",
+    "match_sample",
+    "record_until_silence",
+    "SoundWorker",
+]

--- a/audiokeys/sample_matcher.py
+++ b/audiokeys/sample_matcher.py
@@ -1,0 +1,87 @@
+"""Utility functions for sound-sample matching."""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional
+
+import numpy as np
+
+
+def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    """Return the cosine similarity between ``a`` and ``b``."""
+    if a.size == 0 or b.size == 0:
+        return 0.0
+    n = min(len(a), len(b))
+    a = a[:n]
+    b = b[:n]
+    a_norm = float(np.linalg.norm(a))
+    b_norm = float(np.linalg.norm(b))
+    if a_norm == 0.0 or b_norm == 0.0:
+        return 0.0
+    return float(np.dot(a, b) / (a_norm * b_norm))
+
+
+def match_sample(
+    segment: np.ndarray,
+    samples: Mapping[str, np.ndarray],
+    *,
+    threshold: float = 0.8,
+) -> Optional[str]:
+    """Return the key whose stored sample best matches ``segment``."""
+    best_key: Optional[str] = None
+    best_score: float = 0.0
+    for key, ref in samples.items():
+        score = cosine_similarity(segment, ref)
+        if score > best_score:
+            best_score = score
+            best_key = key
+    if best_key is not None and best_score >= threshold:
+        return best_key
+    return None
+
+
+__all__ = ["cosine_similarity", "match_sample"]
+
+
+def record_until_silence(
+    device_index: int,
+    *,
+    sample_rate: int = 44_100,
+    hop_size: int = 1024,
+    threshold: float = 0.01,
+    silence_duration: float = 0.5,
+    max_duration: float = 5.0,
+    channels: int = 1,
+) -> np.ndarray:
+    """Record audio until ``silence_duration`` of silence is detected."""
+    import sounddevice as sd
+
+    frames: list[np.ndarray] = []
+    silent = 0
+    required = int(silence_duration * sample_rate)
+    limit = int(max_duration * sample_rate)
+    with sd.InputStream(
+        device=device_index,
+        channels=channels,
+        samplerate=sample_rate,
+        blocksize=hop_size,
+        dtype="float32",
+    ) as stream:
+        while sum(len(x) for x in frames) < limit:
+            data, _ = stream.read(hop_size)
+            if data.ndim == 2 and data.shape[1] > 1:
+                block = data.mean(axis=1)
+            else:
+                block = data.reshape(-1)
+            frames.append(block)
+            rms = float(np.sqrt(np.mean(block**2)))
+            if rms < threshold:
+                silent += hop_size
+                if silent >= required and sum(len(x) for x in frames) > hop_size:
+                    break
+            else:
+                silent = 0
+    return np.concatenate(frames)
+
+
+__all__ = ["cosine_similarity", "match_sample", "record_until_silence"]

--- a/audiokeys/sound_worker.py
+++ b/audiokeys/sound_worker.py
@@ -1,0 +1,151 @@
+"""Audio worker for matching recorded sound samples."""
+
+from __future__ import annotations
+
+import gc
+import threading
+from collections import deque
+from typing import Mapping, MutableMapping, Optional
+
+import numpy as np
+import sounddevice as sd
+from PySide6 import QtCore
+from scipy.signal import butter, sosfilt, sosfilt_zi
+
+from .key_sender import KeySender
+from .constants import (
+    BUFFER_SIZE,
+    HOP_SIZE,
+    HP_FILTER_CUTOFF,
+    NOISE_GATE_CALIBRATION_TIME,
+    NOISE_GATE_MARGIN,
+    SAMPLE_RATE,
+)
+from .sample_matcher import match_sample
+from .audio_worker import AdaptiveNoiseGate
+
+
+class SoundWorker(QtCore.QThread):
+    """Capture audio and match blocks against stored samples."""
+
+    keyDetected = QtCore.Signal(str)
+    amplitudeChanged = QtCore.Signal(float)
+
+    def __init__(
+        self,
+        device_index: int,
+        samples: MutableMapping[str, np.ndarray],
+        note_map: Mapping[str, str],
+        *,
+        channels: int = 1,
+        parent: Optional[QtCore.QObject] = None,
+        sample_rate: int = SAMPLE_RATE,
+        buffer_size: int = BUFFER_SIZE,
+        hop_size: int = HOP_SIZE,
+        hp_cutoff: float = HP_FILTER_CUTOFF,
+        noise_gate_duration: float = NOISE_GATE_CALIBRATION_TIME,
+        noise_gate_margin: float = NOISE_GATE_MARGIN,
+        match_threshold: float = 0.8,
+        send_enabled: bool = True,
+    ) -> None:
+        super().__init__(parent)
+        self.device_index = device_index
+        self.samples = samples
+        self.note_map = note_map
+        self.channels = channels
+        self.sample_rate = sample_rate
+        self.buffer_size = buffer_size
+        self.hop_size = hop_size
+        self.match_threshold = match_threshold
+        self._stop_event = threading.Event()
+        self.stream: Optional[sd.InputStream] = None
+        self.buffer: deque[np.ndarray] = deque()
+        self.noise_gate = AdaptiveNoiseGate(
+            duration=noise_gate_duration,
+            margin=noise_gate_margin,
+            sample_rate=sample_rate,
+            hop_size=hop_size,
+        )
+        self.sender = KeySender(self.note_map, send_enabled=send_enabled)
+        self.hp_sos = butter(2, hp_cutoff, "hp", fs=sample_rate, output="sos")
+        self.hp_zi = sosfilt_zi(self.hp_sos)
+
+    # --------------------------------------------------------------
+    def _process_segment(self) -> None:
+        if not self.buffer:
+            return
+        segment = np.concatenate(list(self.buffer))
+        self.buffer.clear()
+        key = match_sample(segment, self.samples, threshold=self.match_threshold)
+        if key is not None:
+            self.sender.press(key)
+            self.keyDetected.emit(key)
+            self.sender.release(key)
+
+    # --------------------------------------------------------------
+    def _callback(self, indata, frames, _time, status) -> None:  # noqa: D401
+        if status:
+            print(f"⚠️  {status}")
+        try:
+            if indata.ndim == 2 and indata.shape[1] > 1:
+                samples = indata.mean(axis=1).astype(np.float32)
+            else:
+                samples = indata.reshape(-1).astype(np.float32)
+
+            samples, self.hp_zi = sosfilt(self.hp_sos, samples, zi=self.hp_zi)
+            current_rms = self.noise_gate.update(samples)
+            self.amplitudeChanged.emit(current_rms)
+
+            if self.noise_gate.noise_floor is None:
+                return
+
+            if self.noise_gate.is_silent(samples):
+                if self.buffer:
+                    self._process_segment()
+                return
+
+            self.buffer.append(samples)
+        except Exception:
+            pass
+
+    # --------------------------------------------------------------
+    def run(self) -> None:  # noqa: D401
+        try:
+            self.stream = sd.InputStream(
+                device=self.device_index,
+                channels=self.channels,
+                samplerate=self.sample_rate,
+                blocksize=self.hop_size,
+                dtype="float32",
+                callback=self._callback,
+            )
+            self.stream.start()
+            while not self._stop_event.is_set():
+                sd.sleep(100)
+            if self.stream is not None:
+                self.stream.stop()
+                self.stream.close()
+        except Exception as e:
+            print(f"Worker error: {e}")
+
+    def stop(self) -> None:
+        if self.stream is not None:
+            try:
+                self.stream.abort()
+            except Exception:
+                pass
+            try:
+                self.stream.close()
+            except Exception:
+                pass
+        self._stop_event.set()
+        del self.sender
+        gc.collect()
+        self.wait(2000)
+
+    def set_send_enabled(self, enabled: bool) -> None:
+        if hasattr(self, "sender"):
+            self.sender.set_send_enabled(enabled)
+
+
+__all__ = ["SoundWorker"]

--- a/tests/test_sample_matcher.py
+++ b/tests/test_sample_matcher.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from audiokeys.sample_matcher import cosine_similarity, match_sample
+
+
+def test_cosine_similarity_basic():
+    a = np.array([1.0, 0.0, 0.0])
+    b = np.array([1.0, 0.0, 0.0])
+    assert cosine_similarity(a, b) == 1.0
+
+
+def test_match_sample():
+    t = np.linspace(0, 1.0, 44100, endpoint=False)
+    ref_a = np.sin(2 * np.pi * 440.0 * t)
+    ref_b = np.sin(2 * np.pi * 880.0 * t)
+    samples = {"a": ref_a, "b": ref_b}
+    segment = np.sin(2 * np.pi * 440.0 * t)
+    assert match_sample(segment, samples, threshold=0.5) == "a"


### PR DESCRIPTION
## Summary
- add `sample_matcher` utilities for storing and matching sound samples
- add `SoundWorker` for sample-based input detection
- modify GUI to record samples per note, highlight matches and remove tuner
- expose new functionality via package `__init__`
- test sample matching utilities

## Testing
- `flake8 || true`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889c06027448322b575ce831944ac06