### PR TITLE
feat: allow multiple samples per key

### DIFF
--- a/audiokeys/utils.py
+++ b/audiokeys/utils.py
@@ -1,8 +1,9 @@
 import getpass
+import os
+import subprocess
 import sys
 import tempfile
-import subprocess
-import os
+from collections.abc import Iterable
 
 
 def elevate_and_setup_uinput():
@@ -68,3 +69,38 @@ def resource_path(relative_path: str) -> str:
         base_path = os.path.abspath(os.path.dirname(__file__))
 
     return os.path.join(base_path, relative_path)
+
+
+def generate_sample_id(base: str, existing: Iterable[str]) -> str:
+    """Return a unique sample identifier.
+
+    The identifier takes the form ``"{base}_{n}"`` where ``n`` is the lowest
+    positive integer that does not collide with ``existing``.
+
+    Parameters
+    ----------
+    base:
+        Base name provided by the user, e.g. ``"tap"``.
+    existing:
+        Collection of identifiers already in use.
+
+    Returns
+    -------
+    str
+        A unique identifier incorporating ``base``.
+    """
+
+    # Ensure the base is safe for filenames by stripping whitespace and
+    # replacing internal spaces with underscores.  This keeps saved ``.npy``
+    # files consistent across platforms.
+    safe_base = base.strip().replace(" ", "_") or "sample"
+    index = 1
+    candidate = f"{safe_base}_{index}"
+    existing_set = set(existing)
+    while candidate in existing_set:
+        index += 1
+        candidate = f"{safe_base}_{index}"
+    return candidate
+
+
+__all__ = ["elevate_and_setup_uinput", "resource_path", "generate_sample_id"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,11 @@
+from audiokeys.utils import generate_sample_id
+
+
+def test_generate_sample_id_unique_increment():
+    existing = {"tap_1", "tap_2"}
+    assert generate_sample_id("tap", existing) == "tap_3"
+
+
+def test_generate_sample_id_spaces_normalised():
+    existing = set()
+    assert generate_sample_id("my tap", existing).startswith("my_tap_1")


### PR DESCRIPTION
## Summary
- prevent GUI freezes by recording in a background thread and showing a modal indicator
- map named sounds with multiple samples to a single key using a new recording dialog
- add helper for generating unique sample IDs with accompanying tests
