### PR TITLE
Group samples per key and prevent duplicate key mappings

### DIFF
--- a/audiokeys/sound_worker.py
+++ b/audiokeys/sound_worker.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import gc
 import threading
 from collections import deque
-from typing import Mapping, MutableMapping, Optional
+from typing import Mapping, MutableMapping, Optional, Sequence
 import time
 
 import numpy as np
@@ -35,7 +35,7 @@ class SoundWorker(QtCore.QThread):
     def __init__(
         self,
         device_index: int,
-        samples: MutableMapping[str, np.ndarray],
+        samples: MutableMapping[str, Sequence[np.ndarray]],
         note_map: Mapping[str, str],
         *,
         channels: int = 1,

--- a/tests/test_sample_matcher.py
+++ b/tests/test_sample_matcher.py
@@ -36,6 +36,15 @@ def test_match_sample_threshold_none() -> None:
     assert key is None
 
 
+def test_match_sample_handles_multiple_refs() -> None:
+    """``match_sample`` should consider all reference samples for a key."""
+    ref1 = np.array([1.0, 0.0, 0.0])
+    ref2 = np.array([0.0, 1.0, 0.0])
+    segment = ref2 + np.random.normal(0, 0.01, size=3)
+    key = match_sample(segment, {"x": [ref1, ref2]}, threshold=0.5)
+    assert key == "x"
+
+
 def test_record_until_silence_stop(monkeypatch: pytest.MonkeyPatch) -> None:
     class DummyStream:
         def __enter__(self) -> "DummyStream":


### PR DESCRIPTION
## Summary
- allow multiple reference samples to be stored under one key mapping
- block duplicate key assignments and keep grouped samples when editing or deleting
- support matching against multiple samples per key and test new behaviour